### PR TITLE
se reemplazo la variable global 'servicios' por modulos estilo ES6

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,8 +187,8 @@
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
     <script defer src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js" integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" crossorigin="anonymous"></script>
-    <script defer type="text/javascript" src="js/db.js"></script>
-    <script defer type="text/javascript" src="js/codigo.js"></script>
+
+    <script defer type="module" src="js/codigo.js"></script>
     
 </body>
 </html>

--- a/js/codigo.js
+++ b/js/codigo.js
@@ -1,3 +1,5 @@
+import { servicios } from './db.js';
+
 /* function login() {
     const nombre =document.querySelector('#inputname').value;
     const edad =document.querySelector('#inputedad').value;
@@ -111,7 +113,7 @@ function leerDatosServicio(servicio) {
     }
 
     const existe = articulosCarrito.some(servicio=> servicio.id===infoServicio.id);
-/*     console.log(existe); */
+    console.log(existe); 
 
     if(existe){
         const service =articulosCarrito.map(items=> {
@@ -164,8 +166,8 @@ function carritoHTML(){
 
     limpiarHTML();
     
-    arraySubtotal=[];
-    total=0;
+    let arraySubtotal=[];
+    let total=0;
 
     articulosCarrito.forEach( servicio => {
         /* console.log(servicio); */
@@ -202,8 +204,8 @@ function carritoHTML(){
 
     });
     console.log(arraySubtotal);
-    const precioFinal=(arraySubtotal.reduce(function(a, b){ return a + b; }));
-    console.log(arraySubtotal.reduce(function(a, b){ return a + b; }))
+    const precioFinal=(arraySubtotal === undefined || arraySubtotal.length == 0) ? 0 : (arraySubtotal.reduce(function(a, b){ return a + b; }));
+    console.log(precioFinal)
 
     
         const row2=document.createElement('tr');
@@ -255,7 +257,7 @@ $(document).ready(function()
 
   
     function doBounce(element, times, distance, speed) {
-        for(i = 0; i < times; i++) {
+        for(let i = 0; i < times; i++) {
             element.animate({marginTop: '-='+distance},speed)
                 .animate({marginTop: '+='+distance},speed);
         }        

--- a/js/db.js
+++ b/js/db.js
@@ -49,5 +49,5 @@ const servicios = [
     },
 ];
 
-
+export { servicios };
 /* console.log(servicios); */


### PR DESCRIPTION
Tuve que hacer algunos cambios más (ademas del `export`/`import`) porque al usar módulos, el navegador interpreta el código en forma `strict` y no permite ciertas cosas, como usar variables sin haberlas declarado antes